### PR TITLE
Update the group of people who can decrypt backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This container backs up the Rattic database to the `rattic.backup` S3
 bucket. The backups are GPG encrypted, and the recipients are specified
 at the end of `files/rattic.conf`. At the time of writing, they are:
 
-- A19A21B3: steve.marshal@digital.justice.gov.uk
-- 65B16CD7: trent.greenwood@digital.justice.gov.uk
-- E4188C65: niall.creech@digital.justice.gov.uk
-- 2345602A: leonidas.tsampros@digital.justice.gov.uk
+- A19A21B3: steve.marshal@digital.justice.gov.uk, expires 2018-11-18
+- 65B16CD7: trent.greenwood@digital.justice.gov.uk, expires 2019-05-07
+- E4188C65: niall.creech@digital.justice.gov.uk, no expiry
+- 2345602A: leonidas.tsampros@digital.justice.gov.uk, expires 2016-10-18

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # rattic-docker
 Rattic docker image build
+
+# Backup destination and users
+
+This container backs up the Rattic database to the `rattic.backup` S3
+bucket. The backups are GPG encrypted, and the recipients are specified
+at the end of `files/rattic.conf`. At the time of writing, they are:
+
+- A19A21B3: steve.marshal@digital.justice.gov.uk
+- 65B16CD7: trent.greenwood@digital.justice.gov.uk
+- E4188C65: niall.creech@digital.justice.gov.uk
+- 2345602A: leonidas.tsampros@digital.justice.gov.uk

--- a/files/rattic.conf
+++ b/files/rattic.conf
@@ -103,5 +103,11 @@ from_email = ratticdb@rattic.service.dsd.io
 [backup]
 dir = /tmp
 gpg_home = /root/.gnupg
-recipients = B0C90493, 298921E7, A19A21B3, 65B16CD7
 s3_bucket = rattic.backup
+
+# People who can decrypt the backup:
+# - A19A21B3 steve.marshal@digital.justice.gov.uk
+# - 65B16CD7 trent.greenwood@digital.justice.gov.uk
+# - E4188C65 niall.creech@digital.justice.gov.uk
+# - 2345602A leonidas.tsampros@digital.justice.gov.uk
+recipients = A19A21B3, 65B16CD7, E4188C65, 2345602A


### PR DESCRIPTION
Ash and Ciprian left _ages_ ago, and their keys cause the backup to
fail. Add Leonidas and Niall in their place because they're the most
likely to need to rebuild Rattic if it falls over.

Also update the documentation accordingly.
