### PR TITLE
Enable supervisorctl use

### DIFF
--- a/files/supervisord.conf
+++ b/files/supervisord.conf
@@ -1,3 +1,12 @@
+[unix_http_server]
+file=/var/run/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
 [supervisord]
 nodaemon = true
 


### PR DESCRIPTION
We shouldn't _really_ need to use supervisorctl from inside the
container, but it's sometimes useful to be able to debug what's going
on with the running processes.
